### PR TITLE
feat: parse service

### DIFF
--- a/jupyter-notebook/jupyter.yaml
+++ b/jupyter-notebook/jupyter.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jupyter
+  namespace: jupyter
+  labels:
+    run: jupyter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: jupyter
+  template:
+    metadata:
+      labels:
+        run: jupyter
+    spec:
+      containers:
+        - name: jupyter
+          image: jupyter/scipy-notebook:abdb27a6dfbb
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always

--- a/mongo-cluster/statefulset.yaml
+++ b/mongo-cluster/statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: mongo
-  namespace: mongo-cluster
+  namespace: default
 spec:
   serviceName: "mongo"
   replicas: 3
@@ -15,6 +15,16 @@ spec:
         app: mongo
     spec:
       containers:
+        - name: init-mongo
+          image: mongo:3.4.1
+          command:
+            - bash
+            - /config/init.sh
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: mongo-persistent-storage
+              mountPath: /data/db
         - name: mongodb
           image: mongo:3.4.1
           command:
@@ -35,17 +45,6 @@ spec:
                 - db.serverStatus()
             initialDelaySeconds: 10
             timeoutSeconds: 10
-      initContainers:
-        - name: init-mongo
-          image: mongo:3.4.1
-          command:
-            - bash
-            - /config/init.sh
-          volumeMounts:
-            - name: config
-              mountPath: /config
-            - name: mongo-persistent-storage
-              mountPath: /data/db
       volumes:
         - name: config
           configMap:

--- a/parse-service/README.md
+++ b/parse-service/README.md
@@ -1,0 +1,64 @@
+## Prerequisites
+
+Parse uses a MongoDB cluster for its storage. Please check `mongo-cluster` described at the root of this repository in order to know how to set up a
+replicated MongoDB cluster using Kubernetes StatefulSets. This section assumes:
+- You have a three-replica Mongo cluster running in Kubernetes with the names mongo-0.mongo, mongo-1.mongo, and mongo-2.mongo.
+- You have a Docker login; if you don't have one, you can get one for free at https://docker.com.
+- You have a Kubernetes cluster deployed and the kubectl tool properly configured.
+
+## Step 1: Create Mongo Cluster
+Refer to `mongo-cluster` [repo](..\mongo-cluster).
+
+Note: make sure mongo cluster and parse resources are created under the same namespace.
+
+## Step 2: Apply resources
+1. Deployment: contains the parse service with a cmd config to target the Mongo cluster.
+
+```bash
+kubectl apply -f parse.yaml
+```
+
+2. Service: enables DNS-based Pod discovery
+
+```bash
+kubectl apply -f service.yaml
+```
+## Step 3: Connect to the pod
+
+Run to get pod name
+```bash
+kubectl get pods -l run=parse-server
+```
+
+You will get something like 
+
+```bash
+NAME                            READY   STATUS    RESTARTS   AGE
+parse-server-xxxxxxxxxx-xxxxx   1/1     Running   0          5m
+```
+
+Connect to pod:
+```bash
+kubectl exec -it <pod-name> -- /bin/bash
+```
+
+Test parse server internally
+
+```bash
+curl -X GET \
+  -H "X-Parse-Application-Id: test-id" \
+  http://localhost:1337/parse/health
+```
+
+📦 Tip: Install curl if missing
+If the pod lacks curl, you can use a debug pod instead:
+
+```bash
+kubectl run curl-pod --image=curlimages/curl -it --rm -- sh
+```
+Then test with:
+
+```bash
+curl http://parse-server.default.svc.cluster.local:1337/parse/health \
+  -H "X-Parse-Application-Id: test-id"
+```

--- a/parse-service/parse.yaml
+++ b/parse-service/parse.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: parse-server
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: parse-server
+  template:
+    metadata:
+      labels:
+        run: parse-server
+    spec:
+      containers:
+        - name: parse-server
+          image: fraanaalonso/parser-server
+          command: ["npm", "start", "--"]
+          args:
+            - --appId=test-id
+            - --masterKey=test-master
+            - --serverURL=http://localhost:1337/parse
+            - --databaseURI=mongodb://mongo-0.mongo:27017,mongo-1.mongo:27017,mongo-2.mongo:27017/dev?replicaSet=rs0
+

--- a/parse-service/service.yaml
+++ b/parse-service/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: parse-server
+  namespace: default
+spec:
+  selector:
+    run: parse-server
+  ports:
+    - protocol: TCP
+      port: 1337
+      targetPort: 1337


### PR DESCRIPTION
1. Init setup container in order to configure mongo replicas under `containers`
2. Add parse server with instruction to set it up with mongo cluster
3. Add jupyter notebook template for future reusability